### PR TITLE
optimise construction of invocation level lambdas

### DIFF
--- a/lagom/container.py
+++ b/lagom/container.py
@@ -436,7 +436,8 @@ class _TemporaryInjectionContext(Generic[C]):
 
 def _update_container_singletons(container: Container, singletons: List[Type]):
     new_container = container.clone()
-    loaders = {dep: lambda: container.resolve(dep) for dep in singletons}
-    for (dep, loader) in loaders.items():
-        new_container[dep] = SingletonWrapper(ConstructionWithoutContainer(loader))
+    for dep in singletons:
+        new_container[dep] = SingletonWrapper(
+            ConstructionWithoutContainer(lambda: container.resolve(dep))
+        )
     return new_container

--- a/lagom/container.py
+++ b/lagom/container.py
@@ -1,6 +1,5 @@
 import functools
 import logging
-from copy import copy
 from typing import (
     Dict,
     Type,
@@ -29,7 +28,13 @@ from .exceptions import (
     DependencyNotDefined,
 )
 from .markers import injectable
-from .definitions import normalise, Singleton, construction, Alias
+from .definitions import (
+    normalise,
+    Singleton,
+    Alias,
+    ConstructionWithoutContainer,
+    SingletonWrapper,
+)
 from .util.logging import NullLogger
 from .util.reflection import FunctionSpec, CachingReflector, remove_optional_type
 from .wrapping import apply_argument_updater
@@ -431,7 +436,7 @@ class _TemporaryInjectionContext(Generic[C]):
 
 def _update_container_singletons(container: Container, singletons: List[Type]):
     new_container = container.clone()
-    loaders = {dep: construction(lambda: container.resolve(dep)) for dep in singletons}
+    loaders = {dep: lambda: container.resolve(dep) for dep in singletons}
     for (dep, loader) in loaders.items():
-        new_container[dep] = Singleton(loader)
+        new_container[dep] = SingletonWrapper(ConstructionWithoutContainer(loader))
     return new_container

--- a/lagom/definitions.py
+++ b/lagom/definitions.py
@@ -63,15 +63,15 @@ class Alias(SpecialDepDefinition[X]):
         return container.resolve(self.alias_type, skip_definitions=True)
 
 
-class Singleton(SpecialDepDefinition[X]):
+class SingletonWrapper(SpecialDepDefinition[X]):
     """Builds only once then saves the built instance"""
 
     singleton_type: SpecialDepDefinition
     _instance: Optional[X]
     _thread_lock: Lock
 
-    def __init__(self, singleton_type: TypeResolver):
-        self.singleton_type = normalise(singleton_type)
+    def __init__(self, def_to_wrap: SpecialDepDefinition):
+        self.singleton_type = def_to_wrap
         self._instance = None
         self._thread_lock = Lock()
 
@@ -93,6 +93,13 @@ class Singleton(SpecialDepDefinition[X]):
             return self._instance  # type: ignore
         finally:
             self._thread_lock.release()
+
+
+class Singleton(SingletonWrapper[X]):
+    """Builds only once then saves the built instance"""
+
+    def __init__(self, singleton_type: TypeResolver):
+        super().__init__(normalise(singleton_type))
 
 
 class PlainInstance(SpecialDepDefinition[X]):


### PR DESCRIPTION
Skips all reflection (as it wasn't really required) when building the invocation level singletons.