### PR TITLE
Provide argument to partial/magic_partial that updates the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## NEXT (Some-Date)
 ### Enhancements
 * Added ability for ContainerDebugInfo to be injected.
+* Provide argument to partial/magic_partial that updates the container 
+  before triggering dependency resolution. This opens up a hook for framework
+  integrations to supply things like the Request object.
 
 ### Bug fixes
 None

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -107,6 +107,24 @@ SECRET_MSG = "hello world"
 
 # views.py
 @dependencies.bind_view
-def question_count(request, settings: DjangoSettings):
+def show_secret_message(request, settings: DjangoSettings = injectable):
     return HttpResponse(f"your secret message is: {settings.SECRET_MSG}")
+```
+
+### Injecting Request
+If any argument type hints on `HttpRequest` then the django
+object for the current request will be injected.
+
+```python
+# some_services.py
+class DataStoreForRequest:
+    def __init__(self, request: HttpRequest, db: SomeDb):
+        # Now we can use anything generic we want from the request
+        pass
+
+# views.py
+@dependencies.bind_view
+def question_count(request, store: DataStoreForRequest = injectable):
+    # The `store` here was constructed with the correct request object
+    return HttpResponse(f"Done")
 ```

--- a/lagom/interfaces.py
+++ b/lagom/interfaces.py
@@ -20,6 +20,10 @@ X = TypeVar("X")
 
 BuildingFunction = Callable[[Any], Any]
 
+# A function which takes a container, args and kwargs and updates
+# the container before any dependency resolution happens
+CallTimeContainerUpdate = Callable[["WriteableContainer", List, Dict], None]
+
 
 class ReadableContainer(ABC):
     """
@@ -36,7 +40,10 @@ class ReadableContainer(ABC):
 
     @abstractmethod
     def partial(
-        self, func: Callable[..., X], shared: List[Type] = None,
+        self,
+        func: Callable[..., X],
+        shared: List[Type] = None,
+        container_updater: Optional[CallTimeContainerUpdate] = None,
     ) -> Callable[..., X]:
         pass
 
@@ -47,6 +54,7 @@ class ReadableContainer(ABC):
         shared: List[Type] = None,
         keys_to_skip: List[str] = None,
         skip_pos_up_to: int = 0,
+        container_updater: Optional[CallTimeContainerUpdate] = None,
     ) -> Callable[..., X]:
         pass
 

--- a/lagom/version.py
+++ b/lagom/version.py
@@ -1,5 +1,5 @@
 """Module for tracking the version of the library"""
-__version__ = "1.0.0-beta.4"
+__version__ = "1.0.0-beta.5"
 
 if __name__ == "__main__":
     print(__version__)

--- a/tests/test_magic_partial_functions.py
+++ b/tests/test_magic_partial_functions.py
@@ -5,6 +5,7 @@ import pytest
 
 from lagom import Container, magic_bind_to_container
 from lagom.exceptions import UnableToInvokeBoundFunction
+from lagom.interfaces import WriteableContainer
 
 
 class MyDep:
@@ -137,3 +138,19 @@ def test_deps_are_loaded_at_call_time_not_definition_time():
 def test_name_and_docs_are_kept():
     assert another_example_function.__name__ == "another_example_function"
     assert another_example_function.__doc__ == "\n    I am DOCS\n    "
+
+
+def test_partials_can_be_provided_with_an_update_method(container: Container):
+    def _my_func(a, b: MyDep):
+        return a, b
+
+    def _dep_two_is_dep_one(c: WriteableContainer, a, k):
+        # We'll do something a bit weird and say the container
+        # always injects the first supplied argument when asked for
+        # a MyDep. Don't do this for real.
+        c[MyDep] = a[0]
+
+    weird = container.magic_partial(_my_func, container_updater=_dep_two_is_dep_one)
+
+    arg_1, arg_2 = weird("hello")
+    assert arg_1 == arg_2

--- a/tests/test_partial_functions.py
+++ b/tests/test_partial_functions.py
@@ -5,6 +5,7 @@ import pytest
 
 from lagom import Container, bind_to_container, injectable
 from lagom.exceptions import UnresolvableType
+from lagom.interfaces import WriteableContainer
 
 
 class MyDep:
@@ -142,3 +143,19 @@ def test_deps_are_loaded_at_call_time_not_definition_time():
 def test_name_and_docs_are_kept():
     assert another_example_function.__name__ == "another_example_function"
     assert another_example_function.__doc__ == "\n    I am DOCS\n    "
+
+
+def test_partials_can_be_provided_with_an_update_method(container: Container):
+    def _my_func(a, b: MyDep = injectable):
+        return a, b
+
+    def _dep_two_is_dep_one(c: WriteableContainer, a, k):
+        # We'll do something a bit weird and say the container
+        # always injects the first supplied argument when asked for
+        # a MyDep. Don't do this for real.
+        c[MyDep] = a[0]
+
+    weird = container.partial(_my_func, container_updater=_dep_two_is_dep_one)
+
+    arg_1, arg_2 = weird("hello")
+    assert arg_1 == arg_2


### PR DESCRIPTION
 This happens before triggering dependency resolution. This opens up a hook for framework integrations to supply things like the Request object.