### PR TITLE
Support Classes with partial/magic_partial

### DIFF
--- a/lagom/container.py
+++ b/lagom/container.py
@@ -15,6 +15,7 @@ from typing import (
     cast,
     Union,
 )
+from types import FunctionType
 
 from .interfaces import (
     SpecialDepDefinition,
@@ -316,13 +317,20 @@ class Container(
         :return:
         """
         update_container = container_updater if container_updater else _update_nothing
-        spec = self._reflector.get_function_spec(func)
+
+        skip_pos_start_at = 0
+
+        if isinstance(func, FunctionType):
+            spec = self._reflector.get_function_spec(func)
+        else:
+            spec = self._reflector.get_function_spec(func.__init__)
+            skip_pos_start_at = 1
 
         _injection_context = self.temporary_singletons(shared)
 
         def _update_args(supplied_args, supplied_kwargs):
             final_keys_to_skip = (keys_to_skip or []) + list(supplied_kwargs.keys())
-            final_skip_pos_up_to = max(skip_pos_up_to, len(supplied_args))
+            final_skip_pos_up_to = max(skip_pos_up_to, len(supplied_args)) + skip_pos_start_at
             with _injection_context as with_singletons:
                 invocation_container = with_singletons.clone()
                 update_container(invocation_container, supplied_args, supplied_kwargs)
@@ -331,6 +339,7 @@ class Container(
                     suppress_error=True,
                     keys_to_skip=final_keys_to_skip,
                     skip_pos_up_to=final_skip_pos_up_to,
+                    skip_pos_start_at=skip_pos_start_at,
                 )
             kwargs.update(supplied_kwargs)
             return supplied_args, kwargs
@@ -395,8 +404,9 @@ class Container(
         keys_to_skip: List[str] = None,
         skip_pos_up_to=0,
         types_to_skip: Set[Type] = None,
+        skip_pos_start_at=0
     ):
-        supplied_arguments = spec.args[0:skip_pos_up_to]
+        supplied_arguments = spec.args[skip_pos_start_at:skip_pos_up_to]
         keys_to_skip = (keys_to_skip or []) + supplied_arguments
         types_to_skip = types_to_skip or set()
         sub_deps = {

--- a/lagom/container.py
+++ b/lagom/container.py
@@ -14,6 +14,7 @@ from typing import (
     Generic,
     cast,
     Union,
+    Tuple
 )
 from types import FunctionType
 
@@ -266,15 +267,7 @@ class Container(
         :return:
         """
         update_container = container_updater if container_updater else _update_nothing
-        
-        skip_pos_start_at = 0
-
-        if isinstance(func, FunctionType):
-            spec = self._reflector.get_function_spec(func)
-        else:
-            spec = self._reflector.get_function_spec(func.__init__)
-            skip_pos_start_at = 1
-        
+        (spec, skip_pos_start_at) = self._get_spec_and_arg_index(func)
         keys_to_bind = (
             key for (key, arg) in spec.defaults.items() if arg is injectable
         )
@@ -327,15 +320,7 @@ class Container(
         :return:
         """
         update_container = container_updater if container_updater else _update_nothing
-
-        skip_pos_start_at = 0
-
-        if isinstance(func, FunctionType):
-            spec = self._reflector.get_function_spec(func)
-        else:
-            spec = self._reflector.get_function_spec(func.__init__)
-            skip_pos_start_at = 1
-
+        (spec, skip_pos_start_at) = self._get_spec_and_arg_index(func)
         _injection_context = self.temporary_singletons(shared)
 
         def _update_args(supplied_args, supplied_kwargs):
@@ -427,6 +412,15 @@ class Container(
             and (sub_dep_type not in types_to_skip)
         }
         return {key: dep for (key, dep) in sub_deps.items() if dep is not None}
+
+    def _get_spec_and_arg_index(self, func: Callable[..., X]) -> Tuple[bool, int]:
+        if isinstance(func, FunctionType):
+            spec = self._reflector.get_function_spec(func)
+            arg_index = 0
+        else:
+            spec = self._reflector.get_function_spec(func.__init__)
+            arg_index = 1
+        return (spec, arg_index)
 
 
 class ExplicitContainer(Container):

--- a/lagom/container.py
+++ b/lagom/container.py
@@ -267,7 +267,7 @@ class Container(
         :return:
         """
         update_container = container_updater if container_updater else _update_nothing
-        (spec, skip_pos_start_at) = self._get_spec_and_arg_index(func)
+        spec = self._get_spec_without_self(func)
         keys_to_bind = (
             key for (key, arg) in spec.defaults.items() if arg is injectable
         )
@@ -278,7 +278,7 @@ class Container(
         def _update_args(supplied_args, supplied_kwargs):
             keys_to_skip = set(supplied_kwargs.keys())
             keys_to_skip.update(
-                spec.args[skip_pos_start_at:len(supplied_args) + skip_pos_start_at]
+                spec.args[0:len(supplied_args)]
             )
             with _injection_context as with_singletons:
                 invocation_container = with_singletons.clone()
@@ -320,12 +320,12 @@ class Container(
         :return:
         """
         update_container = container_updater if container_updater else _update_nothing
-        (spec, skip_pos_start_at) = self._get_spec_and_arg_index(func)
+        spec = self._get_spec_without_self(func)
         _injection_context = self.temporary_singletons(shared)
 
         def _update_args(supplied_args, supplied_kwargs):
             final_keys_to_skip = (keys_to_skip or []) + list(supplied_kwargs.keys())
-            final_skip_pos_up_to = max(skip_pos_up_to, len(supplied_args)) + skip_pos_start_at
+            final_skip_pos_up_to = max(skip_pos_up_to, len(supplied_args))
             with _injection_context as with_singletons:
                 invocation_container = with_singletons.clone()
                 update_container(invocation_container, supplied_args, supplied_kwargs)
@@ -334,7 +334,6 @@ class Container(
                     suppress_error=True,
                     keys_to_skip=final_keys_to_skip,
                     skip_pos_up_to=final_skip_pos_up_to,
-                    skip_pos_start_at=skip_pos_start_at,
                 )
             kwargs.update(supplied_kwargs)
             return supplied_args, kwargs
@@ -399,9 +398,8 @@ class Container(
         keys_to_skip: List[str] = None,
         skip_pos_up_to=0,
         types_to_skip: Set[Type] = None,
-        skip_pos_start_at=0
     ):
-        supplied_arguments = spec.args[skip_pos_start_at:skip_pos_up_to]
+        supplied_arguments = spec.args[0:skip_pos_up_to]
         keys_to_skip = (keys_to_skip or []) + supplied_arguments
         types_to_skip = types_to_skip or set()
         sub_deps = {
@@ -413,14 +411,14 @@ class Container(
         }
         return {key: dep for (key, dep) in sub_deps.items() if dep is not None}
 
-    def _get_spec_and_arg_index(self, func: Callable[..., X]) -> Tuple[bool, int]:
+    def _get_spec_without_self(self, func: Callable[..., X]) -> FunctionSpec:
         if isinstance(func, FunctionType):
             spec = self._reflector.get_function_spec(func)
-            arg_index = 0
         else:
             spec = self._reflector.get_function_spec(func.__init__)
-            arg_index = 1
-        return (spec, arg_index)
+            if "self" in spec.args:
+                spec.args.remove("self")
+        return spec
 
 
 class ExplicitContainer(Container):

--- a/lagom/container.py
+++ b/lagom/container.py
@@ -14,7 +14,7 @@ from typing import (
     Generic,
     cast,
     Union,
-    Tuple
+    Tuple,
 )
 from types import FunctionType
 
@@ -277,9 +277,7 @@ class Container(
 
         def _update_args(supplied_args, supplied_kwargs):
             keys_to_skip = set(supplied_kwargs.keys())
-            keys_to_skip.update(
-                spec.args[0:len(supplied_args)]
-            )
+            keys_to_skip.update(spec.args[0 : len(supplied_args)])
             with _injection_context as with_singletons:
                 invocation_container = with_singletons.clone()
                 update_container(invocation_container, supplied_args, supplied_kwargs)
@@ -415,7 +413,8 @@ class Container(
         if isinstance(func, FunctionType):
             spec = self._reflector.get_function_spec(func)
         else:
-            spec = self._reflector.get_function_spec(func.__init__)
+            t = cast(Type[X], func)
+            spec = self._reflector.get_function_spec(t.__init__)
             if "self" in spec.args:
                 spec.args.remove("self")
         return spec

--- a/tests/test_magic_partial_classes.py
+++ b/tests/test_magic_partial_classes.py
@@ -13,7 +13,6 @@ class Foo:
 container = Container()
 
 
-@magic_bind_to_container(container)
 class Bar:
     def __init__(self, not_injected: str, foo: Foo) -> None:
         self.not_injected = not_injected
@@ -23,30 +22,18 @@ class Bar:
         return self.foo.greet() + self.not_injected
 
 
-class Baz:
-    def __init__(self, not_injected: str, foo: Foo) -> None:
-        self.not_injected = not_injected
-        self.foo = foo
-
-    def greet(self) -> str:
-        return self.foo.greet() + self.not_injected
-
-
 def test_partial_application_can_be_applied_to_class():
-    baz = container.magic_partial(Baz)(not_injected="!")
-    assert baz.greet() == "Hello Foo!"
+    bar = container.magic_partial(Bar)(not_injected="!")
+    assert bar.greet() == "Hello Foo!"
 
 
 def test_passed_in_arguments_are_used_over_container_generated_ones_when_positional():
-    partial_baz = container.magic_partial(Baz)    
-    assert partial_baz("!", Foo(name="Local")).greet() == "Hello Local!"
+    partial_bar = container.magic_partial(Bar)
+    assert partial_bar("!", Foo(name="Local")).greet() == "Hello Local!"
 
 
 def test_passed_in_arguments_are_used_over_container_generated_ones_when_named():
-    partial_baz = container.magic_partial(Baz)
-    assert partial_baz(not_injected="!", foo=Foo(name="Local")).greet() == "Hello Local!"
-
-
-def test_a_decorator_can_be_used_to_bind_as_well():
-    bar = Bar(not_injected="!!!")
-    assert bar.greet() == "Hello Foo!!!"
+    partial_bar = container.magic_partial(Bar)
+    assert (
+        partial_bar(not_injected="!", foo=Foo(name="Local")).greet() == "Hello Local!"
+    )

--- a/tests/test_magic_partial_classes.py
+++ b/tests/test_magic_partial_classes.py
@@ -1,0 +1,52 @@
+from lagom import Container
+from lagom.decorators import magic_bind_to_container
+
+
+class Foo:
+    def __init__(self, name="Foo") -> None:
+        self._name = name
+
+    def greet(self) -> str:
+        return f"Hello {self._name}"
+
+
+container = Container()
+
+
+@magic_bind_to_container(container)
+class Bar:
+    def __init__(self, not_injected: str, foo: Foo) -> None:
+        self.not_injected = not_injected
+        self.foo = foo
+
+    def greet(self) -> str:
+        return self.foo.greet() + self.not_injected
+
+
+class Baz:
+    def __init__(self, not_injected: str, foo: Foo) -> None:
+        self.not_injected = not_injected
+        self.foo = foo
+
+    def greet(self) -> str:
+        return self.foo.greet() + self.not_injected
+
+
+def test_partial_application_can_be_applied_to_class():
+    baz = container.magic_partial(Baz)(not_injected="!")
+    assert baz.greet() == "Hello Foo!"
+
+
+def test_passed_in_arguments_are_used_over_container_generated_ones_when_positional():
+    partial_baz = container.magic_partial(Baz)    
+    assert partial_baz("!", Foo(name="Local")).greet() == "Hello Local!"
+
+
+def test_passed_in_arguments_are_used_over_container_generated_ones_when_named():
+    partial_baz = container.magic_partial(Baz)
+    assert partial_baz(not_injected="!", foo=Foo(name="Local")).greet() == "Hello Local!"
+
+
+def test_a_decorator_can_be_used_to_bind_as_well():
+    bar = Bar(not_injected="!!!")
+    assert bar.greet() == "Hello Foo!!!"

--- a/tests/test_partial_classes.py
+++ b/tests/test_partial_classes.py
@@ -13,7 +13,6 @@ class Foo:
 container = Container()
 
 
-@bind_to_container(container)
 class Bar:
     def __init__(self, not_injected: str, foo: Foo = injectable) -> None:
         self.not_injected = not_injected
@@ -23,30 +22,18 @@ class Bar:
         return self.foo.greet() + self.not_injected
 
 
-class Baz:
-    def __init__(self, not_injected: str, foo: Foo = injectable) -> None:
-        self.not_injected = not_injected
-        self.foo = foo
-
-    def greet(self) -> str:
-        return self.foo.greet() + self.not_injected
-
-
 def test_partial_application_can_be_applied_to_class():
-    baz = container.partial(Baz)(not_injected="!")
-    assert baz.greet() == "Hello Foo!"
+    bar = container.partial(Bar)(not_injected="!")
+    assert bar.greet() == "Hello Foo!"
 
 
 def test_passed_in_arguments_are_used_over_container_generated_ones_when_positional():
-    partial_baz = container.partial(Baz)
-    assert partial_baz("!", Foo(name="Local")).greet() == "Hello Local!"
+    partial_bar = container.partial(Bar)
+    assert partial_bar("!", Foo(name="Local")).greet() == "Hello Local!"
 
 
 def test_passed_in_arguments_are_used_over_container_generated_ones_when_named():
-    partial_baz = container.partial(Baz)
-    assert partial_baz(not_injected="!", foo=Foo(name="Local")).greet() == "Hello Local!"
-
-
-def test_a_decorator_can_be_used_to_bind_as_well():
-    bar = Bar(not_injected="!!!")
-    assert bar.greet() == "Hello Foo!!!"
+    partial_bar = container.partial(Bar)
+    assert (
+        partial_bar(not_injected="!", foo=Foo(name="Local")).greet() == "Hello Local!"
+    )

--- a/tests/test_partial_classes.py
+++ b/tests/test_partial_classes.py
@@ -1,0 +1,52 @@
+from lagom import Container, injectable
+from lagom.decorators import bind_to_container
+
+
+class Foo:
+    def __init__(self, name="Foo") -> None:
+        self._name = name
+
+    def greet(self) -> str:
+        return f"Hello {self._name}"
+
+
+container = Container()
+
+
+@bind_to_container(container)
+class Bar:
+    def __init__(self, not_injected: str, foo: Foo = injectable) -> None:
+        self.not_injected = not_injected
+        self.foo = foo
+
+    def greet(self) -> str:
+        return self.foo.greet() + self.not_injected
+
+
+class Baz:
+    def __init__(self, not_injected: str, foo: Foo = injectable) -> None:
+        self.not_injected = not_injected
+        self.foo = foo
+
+    def greet(self) -> str:
+        return self.foo.greet() + self.not_injected
+
+
+def test_partial_application_can_be_applied_to_class():
+    baz = container.partial(Baz)(not_injected="!")
+    assert baz.greet() == "Hello Foo!"
+
+
+def test_passed_in_arguments_are_used_over_container_generated_ones_when_positional():
+    partial_baz = container.partial(Baz)
+    assert partial_baz("!", Foo(name="Local")).greet() == "Hello Local!"
+
+
+def test_passed_in_arguments_are_used_over_container_generated_ones_when_named():
+    partial_baz = container.partial(Baz)
+    assert partial_baz(not_injected="!", foo=Foo(name="Local")).greet() == "Hello Local!"
+
+
+def test_a_decorator_can_be_used_to_bind_as_well():
+    bar = Bar(not_injected="!!!")
+    assert bar.greet() == "Hello Foo!!!"


### PR DESCRIPTION
Resolves #129 

These changes allow calling `Container.partial` and `Container.magic_partial` with a class `Callable`. It also supports using the `bind_to_container` and `magic_bind_to_container` decorators on classes.

Tests added for relevant methods in:

* test_partial_classes.py
* tests_magic_partial_classes.py

Let me know if anything looks strange or if you feel the test coverage is not adequate.