### PR TITLE
handle injecting into starlette HTTPEndpoints + tests

### DIFF
--- a/lagom/integrations/starlette.py
+++ b/lagom/integrations/starlette.py
@@ -90,7 +90,7 @@ class StarletteIntegration:
 
     def wrapped_endpoint_factory(
         self,
-        endpoint: Union[Callable, HTTPEndpoint],
+        endpoint: Union[Callable, Type[HTTPEndpoint]],
         partial_provider: Callable
     ):
         """Builds an instance of a starlette Route with endpoint callables 
@@ -99,10 +99,10 @@ class StarletteIntegration:
         :param endpoint: 
         :param partial_provider:
         """
-        if not (isclass(endpoint) and issubclass(endpoint, HTTPEndpoint)):
-            return partial_provider(endpoint, shared=self._request_singletons)
-
         si = self
+        
+        if not (isinstance(endpoint, type) and issubclass(endpoint, HTTPEndpoint)):
+            return partial_provider(endpoint, shared=self._request_singletons)
 
         class HTTPEndpointProxy(HTTPEndpoint):
         

--- a/lagom/integrations/starlette.py
+++ b/lagom/integrations/starlette.py
@@ -89,23 +89,20 @@ class StarletteIntegration:
         )
 
     def wrapped_endpoint_factory(
-        self,
-        endpoint: Union[Callable, Type[HTTPEndpoint]],
-        partial_provider: Callable
+        self, endpoint: Union[Callable, Type[HTTPEndpoint]], partial_provider: Callable
     ):
-        """Builds an instance of a starlette Route with endpoint callables 
-        bound to the container so dependencies can be auto injected. 
+        """Builds an instance of a starlette Route with endpoint callables
+        bound to the container so dependencies can be auto injected.
 
-        :param endpoint: 
+        :param endpoint:
         :param partial_provider:
         """
         si = self
-        
+
         if not (isinstance(endpoint, type) and issubclass(endpoint, HTTPEndpoint)):
             return partial_provider(endpoint, shared=self._request_singletons)
 
         class HTTPEndpointProxy(HTTPEndpoint):
-        
             def __init__(self, scope, receive, send):
                 super().__init__(scope, receive, send)
                 self.endpoint = endpoint(scope, receive, send)
@@ -123,8 +120,6 @@ class StarletteIntegration:
                 endpoint_instance = object.__getattribute__(self, "endpoint")
                 endpoint_method = endpoint_instance.__getattribute__(name)
 
-                return partial_provider(
-                    endpoint_method, shared=si._request_singletons
-                )
+                return partial_provider(endpoint_method, shared=si._request_singletons)
 
         return HTTPEndpointProxy

--- a/tests/integrations/test_starlette.py
+++ b/tests/integrations/test_starlette.py
@@ -51,7 +51,7 @@ def test_the_starlette_container_can_define_request_level_singletons(container):
 @pytest.mark.asyncio
 async def test_the_starlette_container_handles_async_handlers(container):
     sc = StarletteIntegration(container, request_singletons=[MyDep])
-    
+
     route = sc.route("/", some_async_handler)
 
     assert isinstance(route, Route)
@@ -63,7 +63,7 @@ async def test_the_starlette_container_can_handle_endpoint_classes(container):
     sc = StarletteIntegration(container)
     route = sc.route("/", SomeEndpointHandler)
     assert isinstance(route, Route)
-    
+
     client = TestClient(route)
     response = client.get("/")
 

--- a/tests/integrations/test_starlette.py
+++ b/tests/integrations/test_starlette.py
@@ -1,6 +1,11 @@
-from starlette.routing import Route
+import pytest
 
-from lagom import Container, injectable
+from starlette.routing import Route
+from starlette.endpoints import HTTPEndpoint
+from starlette.responses import PlainTextResponse
+from starlette.testclient import TestClient
+
+from lagom import injectable
 from lagom.integrations.starlette import StarletteIntegration
 
 
@@ -21,6 +26,15 @@ def two_dep_handler(request, dep_one: MyDep = injectable, dep_two: MyDep = injec
     return "singleton" if dep_one is dep_two else "new instances"
 
 
+async def some_async_handler(request, dep: MyDep = injectable):
+    return "ok"
+
+
+class SomeEndpointHandler(HTTPEndpoint):
+    async def get(self, request, dep: MyDep = injectable):
+        return PlainTextResponse("ok")
+
+
 def test_a_special_starlette_container_can_be_used_and_provides_routes(container):
     sc = StarletteIntegration(container)
     route = sc.route("/", some_handler)
@@ -32,3 +46,26 @@ def test_the_starlette_container_can_define_request_level_singletons(container):
     sc = StarletteIntegration(container, request_singletons=[MyDep])
     route = sc.route("/two", two_dep_handler)
     assert route.endpoint({}) == "singleton"
+
+
+@pytest.mark.asyncio
+async def test_the_starlette_container_handles_async_handlers(container):
+    sc = StarletteIntegration(container, request_singletons=[MyDep])
+    
+    route = sc.route("/", some_async_handler)
+
+    assert isinstance(route, Route)
+    assert await route.endpoint({}) == "ok"
+
+
+@pytest.mark.asyncio
+async def test_the_starlette_container_can_handle_endpoint_classes(container):
+    sc = StarletteIntegration(container)
+    route = sc.route("/", SomeEndpointHandler)
+    assert isinstance(route, Route)
+    
+    client = TestClient(route)
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.text == "ok"


### PR DESCRIPTION
Closes #166 

Hey Steve! I was playing around with `lagom` and `starlette` and noticed there was a recent issue about this. 

This PR handles `starlette'`s [class-based views](https://www.starlette.io/endpoints/) hopefully in a reasonably idiomatic way. The basic approach is to wrap the endpoint in a proxy class which ignores existing attributes from `HTTPEndpoint` but otherwise use `lagom`'s DI to wrap what's assumed to be a handler function. 

Now that I look at it in a diff, potentially a more robust approach would be to wrap only attributes named after HTTP methods and otherwise not interfere, since (in theory, not sure why you would since you have no control over the way `__init__` gets called) there could be custom non-route properties on a subclass of `HTTPEndpoint`. 

Happy to discuss / make changes either way! 