### PR TITLE
implement override_for_test for fastapi container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 * Starlette integration now has support for web sockets. #173. Thanks again @MisterKeefe
+* FastApi integration provides method to support altering dependency chains during test.
 
 ### Bug Fixes
 None

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -164,3 +164,18 @@ is automatically made available:
 def hello(name, io: ClickIO = injectable):
     io.echo(f"Hello {name}")
 ```
+
+## Flask Blueprints
+The integration has the same interface as for apps:
+
+```python
+from lagom.experimental.integrations.flask import FlaskBlueprintIntegration
+
+simple_page = Blueprint('simple_page', template_folder='templates')
+simple_page_with_deps = FlaskBlueprintIntegration(simple_page, container)
+
+@simple_page_with_deps.route("/save_it/<string:thing_to_save>", methods=['POST'])
+def save_to_db(thing_to_save, db: Database = injectable):
+    db.save(thing_to_save)
+    return 'saved'
+```

--- a/docs/framework_integrations.md
+++ b/docs/framework_integrations.md
@@ -63,7 +63,25 @@ class SomeExtendedRequest:
 Each time SomeExtendedRequest is created the correct `Request`
 object will be passed in.
 
-## Request level singletons
+### Swapping for mocks when using the test client
+Lagom encourages testing with dependencies manually passed to the code under test. 
+However, when testing using the test client dependencies will be constructed using
+the lagom container. For this reason you may want to swap out certain dependencies.
+The fastapi integration has a method `override_for_test` which returns a ContextManager
+that can temporarily edit the dependency injection container.
+
+```python
+def test_something():
+    client = TestClient(app)
+    with deps.override_for_test() as test_container:
+        # FooService is an external API so mock it during test
+        test_container[FooService] = Mock(FooService)
+        response = client.get("/")
+        
+    assert response.status_code == 200
+```
+
+### Request level singletons
 When constructing the integration a list of types can be passed
 for request level singletons. Each of these types will only be constructed
 once per request:
@@ -94,20 +112,9 @@ The decorator leaves the original function unaltered so it can be
 used directly in tests.
 
 ### Flask Blueprints
-Experimental support is provided for flask blueprints. The integration
-has the same interface as for apps:
+Experimental support is provided for flask blueprints.
+See documentation here: [Flask blueprint Docs](experimental.md#flask-blueprints)
 
-```python
-from lagom.experimental.integrations.flask import FlaskBlueprintIntegration
-
-simple_page = Blueprint('simple_page', template_folder='templates')
-simple_page_with_deps = FlaskBlueprintIntegration(simple_page, container)
-
-@simple_page_with_deps.route("/save_it/<string:thing_to_save>", methods=['POST'])
-def save_to_db(thing_to_save, db: Database = injectable):
-    db.save(thing_to_save)
-    return 'saved'
-```
 
 ## [Django](https://www.djangoproject.com/)
 A django integration is currently under beta in the experimental module.

--- a/lagom/integrations/fast_api.py
+++ b/lagom/integrations/fast_api.py
@@ -47,6 +47,20 @@ class FastApiIntegration:
 
     @contextmanager
     def override_for_test(self) -> Iterator[WriteableContainer]:
+        """
+        Returns a ContextManager that returns an editiable container
+        that will temporaily alter the dependency injection resolution
+        of all dependencies bound to this container.
+
+            client = TestClient(app)
+            with deps.override_for_test() as test_container:
+                # FooService is an external API so mock it during test
+                test_container[FooService] = Mock(FooService)
+                response = client.get("/")
+            assert response.status_code == 200
+
+        :return:
+        """
         original = self._container
         new_container_for_test = self._container.clone()
         self._container = new_container_for_test  # type: ignore

--- a/tests/integrations/test_fastapi_integration.py
+++ b/tests/integrations/test_fastapi_integration.py
@@ -6,7 +6,8 @@ from lagom.integrations.fast_api import FastApiIntegration
 
 
 class Inner:
-    pass
+    def __init__(self, msg=None):
+        self.msg = msg
 
 
 class Outer:
@@ -24,6 +25,11 @@ async def read_main(outer_one=deps.depends(Outer), outer_two=deps.depends(Outer)
     return {"outer_one": hash(outer_one.inner), "outer_two": hash(outer_two.inner)}
 
 
+@app.get("/inner")
+async def another_route(dep_one=deps.depends(Inner)):
+    return {"data": dep_one.msg}
+
+
 client = TestClient(app)
 
 
@@ -38,3 +44,27 @@ def test_request_singletons_are_different_for_new_requests():
     data_two = client.get("/").json()
 
     assert data_one["outer_one"] != data_two["outer_one"]
+
+
+def test_deps_can_be_overridden_during_test():
+    with deps.override_for_test() as c:
+        c[Inner] = Inner("test_message")
+        call_under_test = client.get("/inner").json()
+    call_after_test = client.get("/inner").json()
+
+    assert call_under_test["data"] == "test_message"
+    assert call_after_test["data"] != "test_message"
+
+
+def test_deps_can_be_overridden_during_test_mutiple_times():
+    with deps.override_for_test() as c1:
+        with deps.override_for_test() as c2:
+            c1[Inner] = Inner("first_level")
+            c2[Inner] = Inner("second_level")
+            second = client.get("/inner").json()
+        first = client.get("/inner").json()
+    outer = client.get("/inner").json()
+
+    assert outer["data"] is None
+    assert first["data"] == "first_level"
+    assert second["data"] == "second_level"


### PR DESCRIPTION
Potential fix for #174. Usage would be like the following:

```python

from fastapi.testclient import TestClient
from my_app.foo import FooService
from my_app import app, deps

@pytest.fixture
def client() -> Generator:
    with TestClient(app) as test_client, deps.override_for_test() as test_container:
        test_container[FooService] = Mock(FooService)
        yield test_client

```

or:

```python

from fastapi.testclient import TestClient
from my_app.foo import FooService
from my_app import app, deps

@pytest.fixture
def mock_dependencies():
    with deps.override_for_test() as test_container:
        test_container[FooService] = Mock(FooService)
        yield


def test_read_main(mock_dependencies):
    client = TestClient(app)
    response = client.get("/")
    assert response.status_code == 200

```