### PR TITLE
add benchmarking to the compiled code testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,14 @@ jobs:
     - name: Run Tests
       run: |
         pipenv run pytest tests -m "not benchmarking" -vv
+    - name: Run Bechmarking
+      run: |
+        make benchmark
+    - uses: actions/upload-artifact@v2
+      name: Save Benchmarks
+      with:
+        name: benchmark-compiled-results
+        path: .benchmarks/
   test-non-compiled-build:
     name: build-non-compiled-test-${{ matrix.python-version }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since the whole purpose of compilation is to make it faster it should always be able to beat the pure python benchmark