### PR TITLE
Add dependency stack when formatting UnresolvableType

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         find ./dist -name '*.whl'| head -n 1 | xargs pipenv install --skip-lock
     - name: Run Tests
       run: |
-        pipenv run pytest tests -m "not benchmarking not mypyc_failing" -vv
+        pipenv run pytest tests -m "not benchmarking and not mypyc_failing" -vv
     - name: Run Benchmarking
       run: |
         make benchmark

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         find ./dist -name '*.whl'| head -n 1 | xargs pipenv install --skip-lock
     - name: Run Tests
       run: |
-        pipenv run pytest tests -m "not benchmarking" -vv
+        pipenv run pytest tests -m "not benchmarking not mypyc_failing" -vv
     - name: Run Benchmarking
       run: |
         make benchmark

--- a/lagom/container.py
+++ b/lagom/container.py
@@ -180,7 +180,7 @@ class Container(
             # Unless there's already a sync version defined.
             if awaitable_type not in self.defined_types:
                 self._registered_types[awaitable_type] = UnresolvableTypeDefinition(
-                    TypeOnlyAvailableAsAwaitable(awaitable_type)
+                    awaitable_type, TypeOnlyAvailableAsAwaitable(awaitable_type)
                 )
         return definition
 

--- a/lagom/definitions.py
+++ b/lagom/definitions.py
@@ -170,16 +170,18 @@ class UnresolvableTypeDefinition(SpecialDepDefinition[NoReturn]):
     Used to represent a type that should not be built by the container
     """
 
+    dep_type: Type
     _msg_or_exception: Union[str, Exception]
 
-    def __init__(self, msg_or_exception: Union[str, Exception]):
+    def __init__(self, dep_type: Type, msg_or_exception: Union[str, Exception]):
+        self.dep_type = dep_type
         self._msg_or_exception = msg_or_exception
 
     def get_instance(self, container: ReadableContainer) -> NoReturn:
         if isinstance(self._msg_or_exception, Exception):
             raise self._msg_or_exception
         else:
-            raise TypeResolutionBlocked(self._msg_or_exception)
+            raise TypeResolutionBlocked(self.dep_type, self._msg_or_exception)
 
 
 def normalise(

--- a/lagom/exceptions.py
+++ b/lagom/exceptions.py
@@ -116,7 +116,7 @@ class UnresolvableType(ValueError, LagomException):
         error: typing.Optional[BaseException] = self
         unresolvable_deps: typing.List[str] = []
 
-        for _loop_guard in range(100):  # This means there is probably a recursion
+        for _loop_guard in range(100):  # This means there is probably a problem with __cause__
             if not (error and isinstance(error, UnresolvableType)):
                 return unresolvable_deps
             unresolvable_deps.append(error.dep_type)

--- a/lagom/exceptions.py
+++ b/lagom/exceptions.py
@@ -121,6 +121,7 @@ class UnresolvableType(ValueError, LagomException):
                 return unresolvable_deps
             unresolvable_deps.append(error.dep_type)
             error = error.__cause__
+        # This should never happen
         unresolvable_deps.append("...")
         return unresolvable_deps
 

--- a/lagom/exceptions.py
+++ b/lagom/exceptions.py
@@ -116,7 +116,7 @@ class UnresolvableType(ValueError, LagomException):
         error: typing.Optional[BaseException] = self
         unresolvable_deps: typing.List[str] = []
 
-        for _loop_guard in range(100):  # This means there is probably a problem with __cause__
+        for _loop_guard in range(100):
             if not (error and isinstance(error, UnresolvableType)):
                 return unresolvable_deps
             unresolvable_deps.append(error.dep_type)

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 markers =
     benchmarking: slower tests that perform benchmarking on performance
     pypy_failing: tests for behaviour that don't work on pypy
+    mypyc_failing: tests for behaviour that doesn't work on the compiled code

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -137,6 +137,7 @@ class MyService:
         pass
 
 
+@pytest.mark.mypyc_failing
 def test_error_displays_dependency_list(container):
     with pytest.raises(UnresolvableType) as e_info:
         container.resolve(MyService)


### PR DESCRIPTION
This will help users identify which dependency is unresolvable when a UnresolvableType error is thrown.