### PR TITLE
Add ability to make singletons out of async calls

### DIFF
--- a/tests/test_async_definitions_can_be_used.py
+++ b/tests/test_async_definitions_can_be_used.py
@@ -3,7 +3,7 @@ from typing import Awaitable
 
 import pytest
 
-from lagom import Container, dependency_definition
+from lagom import Container, dependency_definition, Singleton
 from lagom.exceptions import TypeOnlyAvailableAsAwaitable
 
 
@@ -30,6 +30,14 @@ async def test_alternative_way_of_defining_an_async_dep(container: Container):
     container[Awaitable[MyComplexDep]] = MyComplexDep.asyc_loader  # type: ignore
 
     assert (await container[Awaitable[MyComplexDep]]) == MyComplexDep(some_number=10)  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_async_singleton_do_not_raise_runtime_error(container: Container):
+    container[Awaitable[MyComplexDep]] = Singleton(MyComplexDep.asyc_loader)  # type: ignore[type-abstract]
+
+    assert (await container[Awaitable[MyComplexDep]]) == MyComplexDep(some_number=10)  # type: ignore[type-abstract]
+    assert (await container[Awaitable[MyComplexDep]]) == MyComplexDep(some_number=10)  # type: ignore[type-abstract]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
As mentioned in #243, currently there's no easy way to use awaitable types as singletons. But I saw this answer https://stackoverflow.com/a/72070356/289932 and it made me think of a way to make a singleton awaitable. 

The trick is to wrap the awaitable object into a task/future object, then the interpreter doesn't complain anymore.

I've followed the path I felt would be ideal: adding a new function `async_construction` that would create either `AsyncConstructionWithoutContainer` or `AsyncConstructionWithContainer`.

There's another way I didn't explore, that was creating a new property in `SingletonWrapper` (maybe `_safe_instance`?) where there's a check if the type is an awaitable one, then wrapping the result into a future object.

Let me know what do you think 🙏 