### PR TITLE
Upgrade pydantic to v2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,11 +20,11 @@ mkdocs = "~=1.2.2"
 mkdocs-material = "*"
 mkdocstrings = {version = "~=0.19.0", extras = ["python"]}
 # Needed for the Env class
-pydantic = "~=1.8"
+pydantic = "~=2.0"
 # Needed for the integrations only
 starlette = "~=0.14"
 httpx = "~=0.23.0"
-fastapi = "~=0.68"
+fastapi = "~=0.100"
 flask = "~=2.1"
 django = "~=3.0"
 click = "*"

--- a/lagom/environment.py
+++ b/lagom/environment.py
@@ -26,7 +26,7 @@ from typing import ClassVar, Optional
 from .exceptions import MissingEnvVariable, InvalidEnvironmentVariables
 
 try:
-    from pydantic.main import BaseModel, ValidationError
+    from pydantic import BaseModel, ValidationError
 except ImportError as error:
     raise ImportError(
         "Using Env requires pydantic to be installed. Try `pip install lagom[env]`"
@@ -65,9 +65,7 @@ class Env(ABC, BaseModel):
                 super().__init__(**kwargs)
         except ValidationError as validation_error:
             missing_field_errors = [
-                e
-                for e in validation_error.errors()
-                if e["type"] == "value_error.missing"
+                e for e in validation_error.errors() if e["type"] == "missing"
             ]
             if missing_field_errors:
                 env_names = self._env_names_from_pydantic_errors(missing_field_errors)

--- a/tests/test_env_wrapper.py
+++ b/tests/test_env_wrapper.py
@@ -8,7 +8,7 @@ from lagom.exceptions import MissingEnvVariable, InvalidEnvironmentVariables
 
 
 class MyEnv(Env):
-    example_value: Optional[str]
+    example_value: Optional[str] = None
 
 
 class MyEnvWithPrefix(Env):


### PR DESCRIPTION
Closes #245 

Upgraded pydantic to v2 and fastapi to >=v0.100 as it uses pydantic v2 from there on.