### PR TITLE
bump django to 5.1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -26,7 +26,7 @@ starlette = "~=0.14"
 httpx = "~=0.23.0"
 fastapi = "~=0.100"
 flask = "~=3.0.3"
-django = "~=3.0"
+django = "~=5.1"
 click = "*"
 
 [packages]


### PR DESCRIPTION
There's better support for newer versions of python in newer versions of django so this needs to be raised to validate lagom works on more recent python versions.