### PR TITLE
fix: add type annotations to dependency_definition decorator (closes #273)

### DIFF
--- a/lagom/decorators.py
+++ b/lagom/decorators.py
@@ -71,7 +71,9 @@ def magic_bind_to_container(
     return _decorator
 
 
-def dependency_definition(container: Container, singleton: bool = False) -> Callable[[Callable[..., T]], Callable[..., T]]:
+def dependency_definition(
+    container: Container, singleton: bool = False
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """Registers the provided function with the container
     The return type of the decorated function will be reflected and whenever
     the container is asked for this type the function will be called

--- a/lagom/decorators.py
+++ b/lagom/decorators.py
@@ -71,7 +71,7 @@ def magic_bind_to_container(
     return _decorator
 
 
-def dependency_definition(container: Container, singleton: bool = False):
+def dependency_definition(container: Container, singleton: bool = False) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """Registers the provided function with the container
     The return type of the decorated function will be reflected and whenever
     the container is asked for this type the function will be called
@@ -86,7 +86,7 @@ def dependency_definition(container: Container, singleton: bool = False):
 
     """
 
-    def _decorator(func):
+    def _decorator(func: Callable[..., T]) -> Callable[..., T]:
         definition_func, return_type = _extract_definition_func_and_type(func)  # type: ignore
 
         if singleton:


### PR DESCRIPTION
## What
The `dependency_definition` decorator had no return type annotation, causing mypy to report:
```
error: Untyped decorator makes function "create_agent_store" untyped  [misc]
```

## Fix
Added proper type annotations to `dependency_definition` so it returns `Callable[[Callable[..., T]], Callable[..., T]]`, and typed the inner `_decorator` function accordingly. This is consistent with how `bind_to_container` and `magic_bind_to_container` are already typed in the same file.

Closes #273