### PR TITLE
fix: make ContextContainer thread-safe using thread-local exit_stack (closes #242)

### DIFF
--- a/lagom/context_based.py
+++ b/lagom/context_based.py
@@ -1,4 +1,5 @@
 import logging
+import threading as _threading
 from contextlib import ExitStack
 from copy import copy
 from typing import (
@@ -94,13 +95,12 @@ class ContextContainer(Container):
     ):
         self._context_types = context_types
         self._context_singletons = context_singletons
-        import threading
-        self._local = threading.local()
+        self._local = _threading.local()
         super().__init__(container, log_undefined_deps)
 
     @property
     def exit_stack(self) -> Optional[ExitStack]:
-        return getattr(self._local, 'exit_stack', None)
+        return getattr(self._local, "exit_stack", None)
 
     @exit_stack.setter
     def exit_stack(self, value: Optional[ExitStack]) -> None:

--- a/lagom/context_based.py
+++ b/lagom/context_based.py
@@ -82,7 +82,6 @@ class ContextContainer(Container):
     <tests.examples.SomeClass object at ...>
     """
 
-    exit_stack: Optional[ExitStack] = None
     _context_types: Collection[Type]
     _context_singletons: Collection[Type]
 
@@ -95,7 +94,17 @@ class ContextContainer(Container):
     ):
         self._context_types = context_types
         self._context_singletons = context_singletons
+        import threading
+        self._local = threading.local()
         super().__init__(container, log_undefined_deps)
+
+    @property
+    def exit_stack(self) -> Optional[ExitStack]:
+        return getattr(self._local, 'exit_stack', None)
+
+    @exit_stack.setter
+    def exit_stack(self, value: Optional[ExitStack]) -> None:
+        self._local.exit_stack = value
 
     def clone(self) -> "ContextContainer":
         """returns a copy of the container


### PR DESCRIPTION
## What
The `ContextContainer` is not thread-safe when the same instance is used as a context manager in parallel threads. The `exit_stack` attribute is shared across all threads on the same instance, causing a race condition: multiple threads can simultaneously see `exit_stack` as `None` in `__enter__`, then overwrite each other's exit stacks, resulting in lost dependency definitions or premature resource cleanup.

## Fix
Replace the plain `exit_stack` instance attribute with a thread-local property backed by `threading.local()`. This ensures each thread has its own isolated `exit_stack`, preventing cross-thread interference while maintaining the existing re-entrant behaviour within a single thread.

Closes #242