### PR TITLE
fix: return None for private underscore attributes on Injectable to support mocking (closes #189)

### DIFF
--- a/lagom/markers.py
+++ b/lagom/markers.py
@@ -43,6 +43,10 @@ class Injectable:
         # it doesn't really help to raise an exception then.
         if item.startswith("__") and item.endswith("__"):
             return None
+        # Ignore private single-underscore attributes used by Python internals
+        # (e.g. _is_coroutine used by asyncio.iscoroutinefunction when mocking)
+        if item.startswith("_"):
+            return None
         raise InjectableNotResolved(
             f"Cannot get {item} on injectable. Make sure the function was bound to a container instance"
         )


### PR DESCRIPTION
## What
When using `unittest.mock.create_autospec` or `@patch` decorators on async functions that use `injectable` as a default argument value, Python's `asyncio.iscoroutinefunction` internally calls `getattr(func, '_is_coroutine', None)`. This triggers `Injectable.__getattr__` with `item='_is_coroutine'`, which raises `InjectableNotResolved` instead of returning `None`.

The existing guard only suppresses dunder attributes (`__x__`), but `_is_coroutine` uses single-underscore naming.

## Fix
Extend the guard in `Injectable.__getattr__` to also return `None` for any attribute starting with a single underscore, as these are internal/private attributes typically accessed by Python internals and decorator machinery rather than user code.

Closes #189